### PR TITLE
Implement custom `fs` option

### DIFF
--- a/lib/file/close.js
+++ b/lib/file/close.js
@@ -1,6 +1,3 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function close( callback ) {
 
   var self = this
@@ -9,13 +6,13 @@ module.exports = function close( callback ) {
     if( this.fd == null ) {
       callback.call( self )
     } else {
-      fs.close( this.fd, function( error ) {
+      this.fs.close( this.fd, function( error ) {
         if( !error ) { self.fd = null }
         callback.call( self, error )
       })
     }
   } else if( this.fd == null ) {
-    fs.close( this.fd )
+    this.fs.close( this.fd )
     this.fd = null
   }
 

--- a/lib/file/create.js
+++ b/lib/file/create.js
@@ -1,6 +1,3 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function create( mode, callback ) {
 
   if( typeof mode === 'function' ) {

--- a/lib/file/delete.js
+++ b/lib/file/delete.js
@@ -1,6 +1,3 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function unlink( callback ) {
 
   if( typeof callback === 'function' ) {
@@ -10,7 +7,7 @@ module.exports = function unlink( callback ) {
     })
   } else {
     this.close()
-    File.delete( this.path )
+    this.constructor.delete( this.path )
   }
 
   return this

--- a/lib/file/exists.js
+++ b/lib/file/exists.js
@@ -1,12 +1,9 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function exists( callback ) {
 
   callback = callback != null ?
     callback.bind( this ) :
     callback
 
-  return File.exists( this.path, callback )
+  return this.constructor.exists( this.path, callback )
 
 }

--- a/lib/file/index.js
+++ b/lib/file/index.js
@@ -5,6 +5,12 @@ var Queue = require( '../queue' )
  * File Constructor
  * @param {String} path
  * @param {Object} options
+ * @param {Object} options.fs - optional, defaults to `require('fs')`
+ * @param {Number} options.fd - optional, file descriptor
+ * @param {String} options.flags - optional, defaults to `'r+'`
+ * @param {Number} options.start - optional
+ * @param {Number} options.end - optional
+ * @param {File} options.parent
  */
 function File( path, options ) {
 
@@ -19,13 +25,14 @@ function File( path, options ) {
 
   options = options || {}
 
-  this.path  = path
-  this.fd    = options.fd
+  this.path = path
+  this.fs = options.fs || fs
+  this.fd = options.fd
   this.flags = options.flags || 'r+'
   this.start = options.start || 0
-  this.end   = options.end
+  this.end = options.end
 
-  this.writes = new Queue( fs, 'write' )
+  this.writes = new Queue( this.fs, 'write' )
   this.slices = []
   this.parent = options.parent
 
@@ -39,8 +46,7 @@ function File( path, options ) {
  * @return {File}
  */
 File.create = function( path, mode, callback ) {
-  return new File( path )
-    .create( mode, callback )
+  return new File( path ).create( mode, callback )
 }
 
 /**
@@ -70,7 +76,7 @@ File.stat = function( path, callback ) {
 /**
  * Truncate a file to a given size
  * @param  {String}   path
- * @param  {Number}   size
+ * @param  {Number}   [size=0]
  * @param  {Function} callback (optional)
  */
 File.allocate =

--- a/lib/file/open.js
+++ b/lib/file/open.js
@@ -1,6 +1,3 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function open( flags, mode, callback ) {
 
   var self = this
@@ -14,7 +11,7 @@ module.exports = function open( flags, mode, callback ) {
   }
 
   if( typeof callback === 'function' ) {
-    fs.open( this.path, flags, mode, function( error, fd ) {
+    this.fs.open( this.path, flags, mode, function( error, fd ) {
       if( error == null ) {
         self.fd = fd
         self.flags = flags
@@ -22,7 +19,7 @@ module.exports = function open( flags, mode, callback ) {
       callback.call( self, error, fd )
     })
   } else {
-    this.fd = fs.openSync( this.path, flags, mode )
+    this.fd = this.fs.openSync( this.path, flags, mode )
     this.flags = flags
   }
 

--- a/lib/file/read-stream.js
+++ b/lib/file/read-stream.js
@@ -1,6 +1,3 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function readStream( start, end, options ) {
 
   if( arguments.length === 1 && typeof start === 'object' ) {
@@ -36,6 +33,6 @@ module.exports = function readStream( start, end, options ) {
   options.end = options.end != null ?
     options.end - 1 : options.end
 
-  return fs.createReadStream( this.path, options )
+  return this.fs.createReadStream( this.path, options )
 
 }

--- a/lib/file/read.js
+++ b/lib/file/read.js
@@ -1,6 +1,3 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function read( offset, length, callback ) {
 
   var self = this
@@ -33,7 +30,7 @@ module.exports = function read( offset, length, callback ) {
       buffer = new Buffer( length )
       buffer.fill( 0 )
 
-      fs.read(
+      self.fs.read(
         this.fd, buffer, 0, length, offset,
         function( error, bytesRead, buffer ) {
           callback.call( self, error, bytesRead, buffer )
@@ -56,9 +53,7 @@ module.exports = function read( offset, length, callback ) {
     buffer = new Buffer( length )
     buffer.fill( 0 )
 
-    fs.readSync(
-      this.fd, buffer, 0, length, offset
-    )
+    this.fs.readSync( this.fd, buffer, 0, length, offset )
 
   }
 

--- a/lib/file/rename.js
+++ b/lib/file/rename.js
@@ -1,6 +1,3 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function rename( path, callback ) {
 
   var self = this
@@ -12,7 +9,7 @@ module.exports = function rename( path, callback ) {
       if( error != null )
         return callback.call( this, error )
 
-      fs.rename( this.path, path, function( error ) {
+      self.fs.rename( this.path, path, function( error ) {
 
         if( error != null )
           return callback.call( self, error )

--- a/lib/file/slice.js
+++ b/lib/file/slice.js
@@ -1,5 +1,3 @@
-var fs = require( 'fs' )
-
 module.exports = function slice( start, end, create ) {
 
   var stat = this.stat()

--- a/lib/file/stat.js
+++ b/lib/file/stat.js
@@ -1,8 +1,5 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function stat( callback ) {
   return ( typeof callback === 'function' ) ?
-    fs.fstat( this.fd, callback.bind( this ) ) :
-    fs.fstatSync( this.fd )
+    this.fs.fstat( this.fd, callback.bind( this ) ) :
+    this.fs.fstatSync( this.fd )
 }

--- a/lib/file/truncate.js
+++ b/lib/file/truncate.js
@@ -1,6 +1,3 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function truncate( size, callback ) {
 
   if( typeof size !== 'number' ) {
@@ -13,8 +10,8 @@ module.exports = function truncate( size, callback ) {
     callback
 
   typeof callback === 'function' ?
-    fs.ftruncate( this.fd, size, callback ) :
-    fs.ftruncateSync( this.fd, size )
+    this.fs.ftruncate( this.fd, size, callback ) :
+    this.fs.ftruncateSync( this.fd, size )
 
   return this
 

--- a/lib/file/write-stream.js
+++ b/lib/file/write-stream.js
@@ -1,6 +1,3 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function writeStream( start, end, options ) {
 
   if( arguments.length === 1 && typeof start === 'object' ) {
@@ -37,6 +34,6 @@ module.exports = function writeStream( start, end, options ) {
   options.end = options.end != null ?
     options.end - 1 : options.end
 
-  return fs.createWriteStream( this.path, options )
+  return this.fs.createWriteStream( this.path, options )
 
 }

--- a/lib/file/write.js
+++ b/lib/file/write.js
@@ -1,6 +1,3 @@
-var fs = require( 'fs' )
-var File = require( './' )
-
 module.exports = function write( data, offset, callback ) {
 
   var self = this
@@ -36,7 +33,7 @@ module.exports = function write( data, offset, callback ) {
     if( this.__OOB( offset + buffer.length ) )
       throw new Error( 'Length out of bounds' )
 
-    return fs.writeSync(
+    return this.fs.writeSync(
       this.fd, buffer, 0, buffer.length, offset
     )
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "test": "test"
   },
   "scripts": {
-    "test": "node node_modules/mocha/bin/mocha"
+    "test": "mocha"
   }
 }


### PR DESCRIPTION
Enables use of custom `fs` instances (i.e. virtual file systems and such)

```js
var file = new File( '/path/filename.ext', {
  fs: require( './virtualfs.js' ),
})
```